### PR TITLE
fix: rename `reserved_flags` to `flags`

### DIFF
--- a/example-program/examples/send_with_external_call.rs
+++ b/example-program/examples/send_with_external_call.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use anchor_lang::InstructionData;
-use debridge_solana_sdk::{reserved_flags::SetReservedFlag, HashAdapter, POLYGON_CHAIN_ID};
+use debridge_solana_sdk::{flags::SetReservedFlag, HashAdapter, POLYGON_CHAIN_ID};
 use debridge_solana_sdk_example_program::{
     instruction::SendViaDebridgeWithExternalCall, ID as EXAMPLE_ID,
 };
@@ -54,7 +54,7 @@ fn main() {
             receiver: hex::decode("cfcc66ee5397b7cdf7228f7502d1e168518c6bb3")
                 .expect("Failed to decode receiver"),
             target_chain_id: POLYGON_CHAIN_ID,
-            reserved_flag: flags,
+            flags,
         }
         .data(),
     };

--- a/example-program/programs/debridge-solana-sdk-example-program/src/lib.rs
+++ b/example-program/programs/debridge-solana-sdk-example-program/src/lib.rs
@@ -215,7 +215,7 @@ pub mod debridge_invoke_example {
         receiver: Vec<u8>,
         execution_fee: u64,
         fallback_address: Vec<u8>,
-        reserved_flag: [u8; 32],
+        flags: [u8; 32],
         external_call: Vec<u8>,
     ) -> Result<()> {
         debridge_sending::invoke_init_external_call(
@@ -232,7 +232,7 @@ pub mod debridge_invoke_example {
                 external_call,
                 execution_fee,
                 fallback_address,
-                reserved_flag,
+                flags,
             )),
             referral_code: None,
         };

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -61,28 +61,28 @@ impl CheckReservedFlag for &[u8; 32] {
 }
 impl CheckReservedFlag for &SendSubmissionParamsInput {
     fn check_bit(self, bit: u8) -> bool {
-        self.reserved_flag.check_bit(bit)
+        self.flags.check_bit(bit)
     }
     fn check_unwrap_eth(self) -> bool {
-        self.reserved_flag.check_unwrap_eth()
+        self.flags.check_unwrap_eth()
     }
     fn check_revert_if_external_call(self) -> bool {
-        self.reserved_flag.check_revert_if_external_call()
+        self.flags.check_revert_if_external_call()
     }
     fn check_proxy_with_sender(self) -> bool {
-        self.reserved_flag.check_proxy_with_sender()
+        self.flags.check_proxy_with_sender()
     }
     fn check_send_hashed_data(self) -> bool {
-        self.reserved_flag.check_send_hashed_data()
+        self.flags.check_send_hashed_data()
     }
     fn check_direct_flow(self) -> bool {
-        self.reserved_flag.check_direct_flow()
+        self.flags.check_direct_flow()
     }
 }
 
 #[cfg(test)]
 mod flag_test {
-    use crate::reserved_flags::{CheckReservedFlag, SetReservedFlag};
+    use crate::flags::{CheckReservedFlag, SetReservedFlag};
 
     #[test]
     fn bit_test() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate core;
 
-pub mod reserved_flags;
+pub mod flags;
 
 use solana_program::pubkey::Pubkey;
 

--- a/src/sending.rs
+++ b/src/sending.rs
@@ -15,7 +15,7 @@ use crate::{
     errors::InvokeError,
     hash::HashAdapter,
     keys::{AssetFeeInfoPubkey, BridgePubkey, ChainSupportInfoPubkey},
-    reserved_flags::SetReservedFlag,
+    flags::SetReservedFlag,
     Error, Pubkey, SolanaKeccak256, BPS_DENOMINATOR, DEBRIDGE_ID, SOLANA_CHAIN_ID,
 };
 
@@ -42,7 +42,7 @@ pub struct SendSubmissionParamsInput {
     /// Reward for execution claim transaction in target chain
     pub execution_fee: u64,
     /// Flags for additional protocol features
-    pub reserved_flag: [u8; 32],
+    pub flags: [u8; 32],
     /// Reserve address for sending tokens if external call fails
     pub fallback_address: Vec<u8>,
     /// Keccak256 hash of external call buffer
@@ -57,7 +57,7 @@ impl SendSubmissionParamsInput {
     pub fn execution_fee_only(execution_fee: u64) -> Self {
         SendSubmissionParamsInput {
             execution_fee,
-            reserved_flag: [0; 32],
+            flags: [0; 32],
             fallback_address: vec![0; 20],
             external_call_shortcut: SolanaKeccak256::hash(&[]),
         }
@@ -69,16 +69,16 @@ impl SendSubmissionParamsInput {
     /// * `external_call` - instructions sending in target chain
     /// * `execution_fee` - amount of execution fee
     /// * `fallback_address` -  reserve address for sending tokens if external call fails
-    /// * `reserved_flag` - flags for additional debridge protocol features
+    /// * `flags` - flags for additional debridge protocol features
     pub fn with_external_call(
         external_call: Vec<u8>,
         execution_fee: u64,
         fallback_address: Vec<u8>,
-        reserved_flag: [u8; 32],
+        flags: [u8; 32],
     ) -> Self {
         SendSubmissionParamsInput {
             execution_fee,
-            reserved_flag,
+            flags,
             fallback_address,
             external_call_shortcut: SolanaKeccak256::hash(external_call.as_slice()),
         }
@@ -95,13 +95,13 @@ impl SendSubmissionParamsInput {
         execution_fee: u64,
         fallback_address: Vec<u8>,
     ) -> Self {
-        let mut reserved_flags = [0; 32];
-        reserved_flags.set_revert_if_external_call();
-        reserved_flags.set_proxy_with_sender();
+        let mut flags = [0; 32];
+        flags.set_revert_if_external_call();
+        flags.set_proxy_with_sender();
 
         SendSubmissionParamsInput {
             execution_fee,
-            reserved_flag: reserved_flags,
+            flags,
             fallback_address,
             external_call_shortcut: SolanaKeccak256::hash(external_call.as_slice()),
         }
@@ -356,7 +356,7 @@ mod tests {
             amount: 1000,
             submission_params: Some(SendSubmissionParamsInput {
                 execution_fee: 100,
-                reserved_flag: [1; 32],
+                flags: [1; 32],
                 fallback_address: vec![15; 32],
                 external_call_shortcut: [16; 32],
             }),


### PR DESCRIPTION
During @JosepBove review we noticed the elephant in the room! Namely the divergence of the name flags within different ecosystems (Rust, JavaScript). So we start to correct this oversight